### PR TITLE
增加IP黑名单功能，拦截上报。

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,7 @@
             [
             "./filter/comboPreprocess"  ,
             "./filter/addExtStream" ,
+            "./filter/blacklist",
             "./filter/excludeParam"  ,
             "./filter/str2Int"  
             ],

--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,12 @@
             "./filter/addExtStream" ,
             "./filter/excludeParam"  ,
             "./filter/str2Int"  
-            ]
+            ],
+    // IP 黑名单，使用正则表达式匹配要被拦截的IP地址
+    // 被以下任何一个正则表达式匹配的IP将会被拦截忽略        
+    "blacklist":[
+        "127\\.0\\.0\\..+"
+    ]
 }
 ```
 

--- a/filter/blacklist.js
+++ b/filter/blacklist.js
@@ -1,0 +1,40 @@
+// 黑名单配置
+var blacklist = global.pjconfig['blacklist'] || [];
+// 黑名单正则
+var blacklistRegExpList = [];
+blacklist.forEach(function (reg) {
+    blacklistRegExpList.push(new RegExp(reg));
+});
+
+/**
+ * 判断ip是否在黑名单里
+ * 黑名单列表支持正则表达式
+ * @param ip 请求的ip
+ * @return {boolean} 是否在黑名单里
+ */
+function inBlacklist(ip) {
+    for (var i = 0; i < blacklistRegExpList.length; i++) {
+        if (blacklistRegExpList[i].test(ip)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Created by halwu
+ * IP黑名单过滤
+ */
+module.exports = function () {
+    return {
+        process: function (data) {
+            var arr = data.data;
+            for (var i = 0; i < arr.length; i++) {
+                var ip = arr[i].ip;
+                if (inBlacklist(ip)) {
+                    throw new Error('请求IP ' + ip + ' 在黑名单内，被拦截。');
+                }
+            }
+        }
+    };
+};

--- a/project.debug.json
+++ b/project.debug.json
@@ -12,5 +12,8 @@
         "./filter/addExt",
         "./filter/excludeParam",
         "./filter/str2Int"
+    ],
+    "blacklist":[
+        "127\\.0\\.0\\..+"
     ]
 }

--- a/project.debug.json
+++ b/project.debug.json
@@ -10,6 +10,7 @@
         "./filter/validateParam",
         "./filter/comboPreprocess",
         "./filter/addExt",
+        "./filter/blacklist",
         "./filter/excludeParam",
         "./filter/str2Int"
     ],

--- a/project.json
+++ b/project.json
@@ -10,7 +10,11 @@
         "./filter/validateParam",
         "./filter/comboPreprocess",
         "./filter/addExt",
+        "./filter/blacklist",
         "./filter/excludeParam",
         "./filter/str2Int"
+    ],
+    "blacklist":[
+        "127\\.0\\.0\\..+"
     ]
 }


### PR DESCRIPTION
应用场景：
百度蜘蛛会运行抓取到的网页，它运行网页的机制和浏览器不同导致上报一些非常奇怪的错误。
这些错误在浏览器上是不会发生的我们没必要关注这些错误。
所以希望通过IP黑名单限制来自百度蜘蛛的IP。
